### PR TITLE
🔒 Remove Hardcoded API Key Exposure in Frontend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ function App({ state, dispatch }: { state: GameState, dispatch: React.Dispatch<a
   const generatePlayerAvatar = async () => {
     setIsGeneratingAvatar(true);
     try {
-      const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
+      const ai = new GoogleGenAI({ apiKey: state.ui.apiKey });
       const prompt = `A highly detailed, dark fantasy portrait of a ${getAgeTag(state.player.age_days, state.player.identity.race)} ${state.player.identity.race} ${state.player.identity.gender}. ${AGE_APPEARANCE[Math.floor(state.player.age_days / 365)] || ''} ${state.player.cosmetics.hair_length} ${state.player.cosmetics.eye_color} eyes. Dark, gritty, atmospheric lighting.`;
       
       const response = await ai.models.generateContent({
@@ -273,7 +273,7 @@ function App({ state, dispatch }: { state: GameState, dispatch: React.Dispatch<a
     if (state.ui.isGeneratingAvatar) return;
     dispatch({ type: 'START_AVATAR_GENERATION' });
     try {
-      const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
+      const ai = new GoogleGenAI({ apiKey: state.ui.apiKey });
       const prompt = `A highly detailed, dark fantasy portrait of a ${getAgeTag(state.player.age_days, state.player.identity.race)} ${state.player.identity.race} ${state.player.identity.gender}. ${AGE_APPEARANCE[Math.floor(state.player.age_days / 365)] || ''} ${state.player.cosmetics.hair_length} ${state.player.cosmetics.eye_color} eyes. Dark, gritty, atmospheric lighting.`;
       
       const response = await ai.models.generateContent({

--- a/src/state/initialState.ts
+++ b/src/state/initialState.ts
@@ -119,7 +119,7 @@ export const initialState: GameState = {
       }
       return a;
     }),
-    apiKey: process.env.GEMINI_API_KEY || "",
+    apiKey: "",
     hordeApiKey: "0000000000",
     ui_scale: 1,
     fullscreen: false,

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -30,6 +30,6 @@ export function getFallbackResponse() {
   };
 }
 
-export const getHealthSemantic = (h: number) => h > 80 ? 'Robust' : h > 50 ? 'Battered' : h > 20 ? 'Bleeding' : 'Death\\'s Door';
+export const getHealthSemantic = (h: number) => h > 80 ? 'Robust' : h > 50 ? 'Battered' : h > 20 ? 'Bleeding' : 'Death\'s Door';
 export const getStaminaSemantic = (s: number) => s > 80 ? 'Energetic' : s > 50 ? 'Winded' : s > 20 ? 'Exhausted' : 'Collapsing';
 export const getTraumaSemantic = (t: number) => t < 20 ? 'Lucid' : t < 50 ? 'Shaken' : t < 80 ? 'Disturbed' : 'Fractured';

--- a/src/utils/workers.ts
+++ b/src/utils/workers.ts
@@ -261,7 +261,7 @@ export function buildImagePrompt(state: GameState) {
   const ageYears = Math.floor(state.player.age_days / 365);
   const ageAppearance = AGE_APPEARANCE[ageYears] || "A young person";
   const afflictions = state.player.afflictions.length > 0 ? state.player.afflictions.join(", ") : "healthy";
-  const cosmetics = \`\${state.player.cosmetics.hair_length} hair, \${state.player.cosmetics.eye_color} eyes, \${state.player.cosmetics.skin_tone} skin, \${state.player.cosmetics.posture} posture\`;
+  const cosmetics = `${state.player.cosmetics.hair_length} hair, ${state.player.cosmetics.eye_color} eyes, ${state.player.cosmetics.skin_tone} skin, ${state.player.cosmetics.posture} posture`;
   
   let biologyTags = "";
   if (state.player.biology.incubations.length > 0 || state.player.biology.parasites.length > 0) {
@@ -275,9 +275,9 @@ export function buildImagePrompt(state: GameState) {
 
   let companionTags = "";
   if (state.player.companions.active_party.length > 0) {
-    companionTags = \`, accompanied by \${state.player.companions.active_party[0].name} (\${state.player.companions.active_party[0].type})\`;
+    companionTags = `, accompanied by ${state.player.companions.active_party[0].name} (${state.player.companions.active_party[0].type})`;
   }
 
   const equipped = state.player.inventory.filter(i => i.is_equipped).map(i => i.name).join(", ") || "nothing";
-  return \`masterpiece, high quality, dark fantasy, Elder Scrolls style, \${state.world.current_location.atmosphere}, \${state.world.weather}, \${timeOfDay}, \${ageAppearance}, character wearing \${equipped}, \${cosmetics}, \${afflictions}\${biologyTags}\${dreamscapeTags}\${companionTags}\`;
+  return `masterpiece, high quality, dark fantasy, Elder Scrolls style, ${state.world.current_location.atmosphere}, ${state.world.weather}, ${timeOfDay}, ${ageAppearance}, character wearing ${equipped}, ${cosmetics}, ${afflictions}${biologyTags}${dreamscapeTags}${companionTags}`;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,6 @@ export default defineConfig(({mode}) => {
   const env = loadEnv(mode, '.', '');
   return {
     plugins: [react(), tailwindcss()],
-    define: {
-      'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
🎯 **What:** The Gemini API key (`process.env.GEMINI_API_KEY`) was being hardcoded into the frontend bundle at build time via `vite.config.ts`, exposing it to the client side.
⚠️ **Risk:** Anyone inspecting the frontend bundle or network requests could easily extract the `GEMINI_API_KEY` and misuse it, potentially incurring costs or breaching API limits.
🛡️ **Solution:** Removed the API key injection from `vite.config.ts`. Initialized the default API key in the application state to an empty string (`src/state/initialState.ts`). Updated the application logic (`src/App.tsx`) to pull the API key exclusively from the user state (`state.ui.apiKey`), meaning the user must bring their own key (as moving to a backend proxy was out of scope for a fast fix). Minor syntax formatting fixes were also applied to string templates in utility functions.

---
*PR created automatically by Jules for task [9338346152930020173](https://jules.google.com/task/9338346152930020173) started by @romeytheAI*