### PR TITLE
🧹 cleanup: remove unused import generateProceduralItem from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,6 @@ import { initialState } from './state/initialState';
 import { gameReducer } from './reducers/gameReducer';
 import { PREDEFINED_ANATOMIES, STABLE_API, DEFAULT_API_KEY, AGE_APPEARANCE } from './constants';
 import { ELDER_SCROLLS_LORE, getRelevantLore } from './lore';
-import { generateProceduralItem } from './utils/procedural';
 import { generateText, generateImage, generateLegendaryStats } from './services/api';
 import { buildTextPromptAsync, buildImagePrompt, imageWorker } from './utils/workers';
 import { getSynergies, getAgeTag, getFallbackResponse, getHealthSemantic, getStaminaSemantic, getTraumaSemantic } from './utils/gameLogic';


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is an unused import of `generateProceduralItem` in `src/App.tsx`.
💡 **Why:** Removing unused imports improves code maintainability, reduces confusion for future developers, and keeps the codebase clean.
✅ **Verification:** Verified that the import was present and unused, then removed it and confirmed the removal via `grep`. A lint check was attempted, but `tsc` was not available; however, this is a safe, non-functional change.
✨ **Result:** A cleaner `src/App.tsx` file with one less unused dependency.

---
*PR created automatically by Jules for task [11052922394805626010](https://jules.google.com/task/11052922394805626010) started by @romeytheAI*