### PR TITLE
🧹 Remove unused NPCS import from App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { SemanticText } from './components/TextComponents';
 import { GameState, Item, StatKey, ActiveEncounter } from './types';
 import { LOCATIONS } from './data/locations';
-import { NPCS } from './data/npcs';
 import { BASIC_ITEMS } from './data/items';
 import { ENCOUNTERS } from './data/encounters';
 import { DIALOGUE_TREES } from './data/dialogueTrees';


### PR DESCRIPTION
🎯 **What:** Removed an unused import of `NPCS` in `src/App.tsx`.
💡 **Why:** This improves maintainability by reducing dead code and keeping the import list relevant to the file's content.
✅ **Verification:** Confirmed that `NPCS` is not referenced anywhere in `src/App.tsx` after the change.
✨ **Result:** Cleaned up `src/App.tsx` by removing unnecessary code.

---
*PR created automatically by Jules for task [12179014653428879802](https://jules.google.com/task/12179014653428879802) started by @romeytheAI*