### PR TITLE
✨ feat: Expand Hammerfell locations

### DIFF
--- a/src/data/esLocations.ts
+++ b/src/data/esLocations.ts
@@ -134,4 +134,72 @@ export const ES_LOCATIONS: Record<string, any> = {
       { id: 'harvest_fungi', label: 'Harvest luminescent fungi', skill: 'foraging', difficulty: 15, reward: { items: ['fungi_spore'], gold: 5 } },
     ],
   },
+
+  loc_es_sentinel: {
+    id: 'loc_es_sentinel',
+    name: 'Sentinel',
+    description: 'The great jewel of Hammerfell, situated on the Iliac Bay. Its white limestone walls reflect the desert sun blindingly, while the harbor bustles with merchants, corsairs, and naval vessels. The smell of exotic spices, sea salt, and ancient wealth permeates the air. The Forebear nobility rule here, their palaces overlooking the bustling bazaars where everything has a price.',
+    danger: 45,
+    atmosphere: 'bustling, hot, cosmopolitan, wealthy',
+    exits: ['crossroads', 'loc_es_stros_m_kai', 'loc_es_sunforge'],
+    features: ['grand_bazaar', 'palace_district', 'iliac_harbor', 'forebear_guard'],
+    npcs: ['npc_es_redguard_merchant', 'npc_es_corsair_captain'],
+    items: ['hammerfell_spice', 'curved_sword', 'iliac_pearl'],
+    actions: [
+      { id: 'haggle_bazaar', label: 'Haggle in the Grand Bazaar', skill: 'skulduggery', difficulty: 35, reward: { gold: 30, items: ['hammerfell_spice'], xp: 20 } },
+      { id: 'listen_corsairs', label: 'Listen to corsair tales at the harbor', skill: 'social', difficulty: 25, reward: { xp: 25, skills: { willpower: 2 } } },
+      { id: 'admire_palace', label: 'Admire the limestone palaces', skill: 'willpower', difficulty: 20, reward: { xp: 15 } },
+    ],
+  },
+
+  loc_es_sunforge: {
+    id: 'loc_es_sunforge',
+    name: 'Sunforge',
+    description: 'A legendary smithy hidden deep within the Dragontail Mountains, where the heat of the earth meets the blinding light of Magnus. Here, the greatest weaponsmiths of Hammerfell craft blades that sing through the air. The intense heat is nearly unbearable, but the rhythmic ringing of hammers against anvils creates a hypnotic, almost magical atmosphere.',
+    danger: 60,
+    atmosphere: 'sweltering, rhythmic, magical, intense',
+    exits: ['loc_es_sentinel', 'loc_es_rihad'],
+    features: ['magma_forge', 'singing_anvils', 'master_smiths', 'heat_shimmer'],
+    npcs: ['npc_es_master_smith', 'npc_es_apprentice_armorer'],
+    items: ['sunforged_ingot', 'singing_steel_blade', 'dragontail_ore'],
+    actions: [
+      { id: 'watch_smiths', label: 'Watch the master smiths at work', skill: 'willpower', difficulty: 40, reward: { xp: 30, skills: { willpower: 3 } } },
+      { id: 'mine_ore', label: 'Mine ore near the magma flows', skill: 'athletics', difficulty: 50, reward: { items: ['dragontail_ore'], gold: 15, xp: 25 } },
+      { id: 'assist_forge', label: 'Assist at the singing anvils', skill: 'athletics', difficulty: 65, reward: { xp: 45, items: ['sunforged_ingot'] } },
+    ],
+  },
+
+  loc_es_rihad: {
+    id: 'loc_es_rihad',
+    name: 'Rihad',
+    description: 'A cosmopolitan port city on the southern coast of Hammerfell, bordering the Abecean Sea and the province of Cyrodiil. Rihad is a melting pot of cultures, where Redguard tradition meets Imperial influence. The city is known for its skilled mercenaries, grand arenas, and the ever-present threat of political intrigue simmering beneath its sun-baked streets.',
+    danger: 55,
+    atmosphere: 'vibrant, tense, martial, sun-baked',
+    exits: ['crossroads', 'loc_es_sunforge'],
+    features: ['grand_arena', 'mercenary_guild', 'imperial_quarter', 'abecean_docks'],
+    npcs: ['npc_es_arena_champion', 'npc_es_imperial_diplomat'],
+    items: ['arena_token', 'rihad_mercenary_contract', 'abecean_coral'],
+    actions: [
+      { id: 'watch_arena', label: 'Watch the fights in the Grand Arena', skill: 'willpower', difficulty: 30, reward: { xp: 25 } },
+      { id: 'train_mercenaries', label: 'Train with the local mercenaries', skill: 'athletics', difficulty: 55, reward: { xp: 40, skills: { athletics: 4 } } },
+      { id: 'search_docks', label: 'Search the docks for interesting finds', skill: 'skulduggery', difficulty: 45, reward: { items: ['abecean_coral'], gold: 20, xp: 20 } },
+    ],
+  },
+
+  loc_es_stros_m_kai: {
+    id: 'loc_es_stros_m_kai',
+    name: 'Stros M\'Kai',
+    description: 'An island off the southern coast of Hammerfell, famous for its deepwater port, its history of rebellion, and the ancient Dwemer ruins that dot its landscape. The air is thick with humidity and the smell of tropical flora. The island serves as a haven for pirates, smugglers, and independent thinkers who chafe under mainland rule.',
+    danger: 65,
+    atmosphere: 'tropical, rebellious, mysterious, lawless',
+    exits: ['loc_es_sentinel'],
+    features: ['port_hunding', 'smugglers_den', 'dwemer_observatory', 'tropical_jungle'],
+    npcs: ['npc_es_restless_league_member', 'npc_es_smuggler_boss'],
+    items: ['stros_mkai_rum', 'dwemer_cog', 'pirate_treasure'],
+    actions: [
+      { id: 'drink_tavern', label: 'Drink rum in a smuggler\'s tavern', skill: 'social', difficulty: 40, reward: { xp: 20, items: ['stros_mkai_rum'] } },
+      { id: 'explore_observatory', label: 'Explore the Dwemer Observatory', skill: 'willpower', difficulty: 60, reward: { xp: 45, items: ['dwemer_cog'] } },
+      { id: 'search_jungle', label: 'Search the jungle for hidden caches', skill: 'foraging', difficulty: 55, reward: { gold: 40, items: ['pirate_treasure'], xp: 35 } },
+    ],
+  },
 };


### PR DESCRIPTION
🎯 **What:** Added 4 new Hammerfell locations to `src/data/esLocations.ts`: Sentinel, Sunforge, Rihad, and Stros M'Kai.

💡 **Why:** To expand the game world as requested by the user, incorporating new explorable areas with unique features, atmospheres, and interactive events.

✅ **Verification:** Verified by checking syntax in `esLocations.ts`. No new tests needed for data addition, and the new data object formatting perfectly matches existing nodes.

✨ **Result:** Players can now explore new interconnected locations in Hammerfell.

---
*PR created automatically by Jules for task [2582156354523027619](https://jules.google.com/task/2582156354523027619) started by @romeytheAI*