### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to icon-only modal close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Adding ARIA Labels to Lucide Icons in Modals
+**Learning:** When using Lucide React icons within buttons for modals, they are inherently inaccessible to screen readers without an explicit aria-label on the parent button tag. This is a common pattern in this project's modals.
+**Action:** Always verify that icon-only buttons in new components, particularly modals, are provided with a descriptive aria-label.

--- a/src/components/modals/InventoryModal.tsx
+++ b/src/components/modals/InventoryModal.tsx
@@ -190,7 +190,7 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ state, dispatch,
               onClick={(e) => e.stopPropagation()}
               className="bg-[#0a0a0a] border border-amber-900/30 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button aria-label="Close" onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label={`Close ${selectedItem.name}`} onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               
               <div className="flex items-center gap-3 mb-6 border-b border-white/10 pb-4">
                 <h2 className="text-2xl font-serif text-amber-500/90 tracking-widest uppercase">{selectedItem.name}</h2>

--- a/src/components/modals/InventoryModal.tsx
+++ b/src/components/modals/InventoryModal.tsx
@@ -49,7 +49,7 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ state, dispatch,
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Possessions</h2>
               
               <div className="grid grid-cols-3 gap-8">
@@ -190,7 +190,7 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ state, dispatch,
               onClick={(e) => e.stopPropagation()}
               className="bg-[#0a0a0a] border border-amber-900/30 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close" onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               
               <div className="flex items-center gap-3 mb-6 border-b border-white/10 pb-4">
                 <h2 className="text-2xl font-serif text-amber-500/90 tracking-widest uppercase">{selectedItem.name}</h2>

--- a/src/components/modals/InventoryModal.tsx
+++ b/src/components/modals/InventoryModal.tsx
@@ -49,7 +49,7 @@ export const InventoryModal: React.FC<InventoryModalProps> = ({ state, dispatch,
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Inventory" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Possessions</h2>
               
               <div className="grid grid-cols-3 gap-8">

--- a/src/components/modals/JournalModal.tsx
+++ b/src/components/modals/JournalModal.tsx
@@ -44,7 +44,7 @@ export const JournalModal: React.FC<JournalModalProps> = ({ state, dispatch }) =
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Journal</h2>
         
         <div className="space-y-6">

--- a/src/components/modals/JournalModal.tsx
+++ b/src/components/modals/JournalModal.tsx
@@ -44,7 +44,7 @@ export const JournalModal: React.FC<JournalModalProps> = ({ state, dispatch }) =
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Journal" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Journal</h2>
         
         <div className="space-y-6">

--- a/src/components/modals/MapModal.tsx
+++ b/src/components/modals/MapModal.tsx
@@ -74,7 +74,7 @@ export const MapModal: React.FC<MapModalProps> = ({ state, dispatch, handleActio
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={handleClose} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Map" onClick={handleClose} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Cartography of Tamriel</h2>
         
         <div className="grid grid-cols-3 gap-8">

--- a/src/components/modals/MapModal.tsx
+++ b/src/components/modals/MapModal.tsx
@@ -74,7 +74,7 @@ export const MapModal: React.FC<MapModalProps> = ({ state, dispatch, handleActio
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={handleClose} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={handleClose} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Cartography of Tamriel</h2>
         
         <div className="grid grid-cols-3 gap-8">

--- a/src/components/modals/ShopModal.tsx
+++ b/src/components/modals/ShopModal.tsx
@@ -59,7 +59,7 @@ export const ShopModal: React.FC<ShopModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_shop', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Shop" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_shop', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         
         {/* Gold display */}
         <div className="flex justify-between items-center mb-6 border-b border-white/10 pb-4">

--- a/src/components/modals/ShopModal.tsx
+++ b/src/components/modals/ShopModal.tsx
@@ -59,7 +59,7 @@ export const ShopModal: React.FC<ShopModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_shop', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_shop', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         
         {/* Gold display */}
         <div className="flex justify-between items-center mb-6 border-b border-white/10 pb-4">

--- a/src/components/modals/SocialModal.tsx
+++ b/src/components/modals/SocialModal.tsx
@@ -95,7 +95,7 @@ export const SocialModal: React.FC<SocialModalProps> = ({ state, dispatch }) => 
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_social', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Social" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_social', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
 
         <div className="flex items-center gap-3 mb-6 border-b border-white/10 pb-4">
           <Users className="w-5 h-5 text-pink-400" />

--- a/src/components/modals/SocialModal.tsx
+++ b/src/components/modals/SocialModal.tsx
@@ -95,7 +95,7 @@ export const SocialModal: React.FC<SocialModalProps> = ({ state, dispatch }) => 
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_social', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_social', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
 
         <div className="flex items-center gap-3 mb-6 border-b border-white/10 pb-4">
           <Users className="w-5 h-5 text-pink-400" />

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -50,7 +50,7 @@ export const StatsModal: React.FC<StatsModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Stats" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Character Essence</h2>
         
         <div className="grid grid-cols-2 gap-8">

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -50,7 +50,7 @@ export const StatsModal: React.FC<StatsModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
         <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Character Essence</h2>
         
         <div className="grid grid-cols-2 gap-8">

--- a/src/components/modals/WardrobeModal.tsx
+++ b/src/components/modals/WardrobeModal.tsx
@@ -77,7 +77,7 @@ export const WardrobeModal: React.FC<WardrobeModalProps> = ({ state, dispatch })
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_wardrobe', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close Wardrobe" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_wardrobe', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
 
         <div className="flex justify-between items-center mb-6 border-b border-white/10 pb-4">
           <div className="flex items-center gap-3">

--- a/src/components/modals/WardrobeModal.tsx
+++ b/src/components/modals/WardrobeModal.tsx
@@ -77,7 +77,7 @@ export const WardrobeModal: React.FC<WardrobeModalProps> = ({ state, dispatch })
         initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_wardrobe', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_wardrobe', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
 
         <div className="flex justify-between items-center mb-6 border-b border-white/10 pb-4">
           <div className="flex items-center gap-3">

--- a/src/components/modals/XRayModal.tsx
+++ b/src/components/modals/XRayModal.tsx
@@ -19,7 +19,7 @@ export const XRayModal: React.FC<XRayModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.95, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.95, opacity: 0 }}
         className="max-w-2xl w-full relative"
       >
-        <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
+        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
         <XRayView anatomy={state.player.anatomy} highlightedPart={state.ui.highlighted_part || undefined} />
       </motion.div>
     </motion.div>

--- a/src/components/modals/XRayModal.tsx
+++ b/src/components/modals/XRayModal.tsx
@@ -19,7 +19,7 @@ export const XRayModal: React.FC<XRayModalProps> = ({ state, dispatch }) => {
         initial={{ scale: 0.95, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.95, opacity: 0 }}
         className="max-w-2xl w-full relative"
       >
-        <button aria-label="Close" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
+        <button aria-label="Close X-Ray" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
         <XRayView anatomy={state.player.anatomy} highlightedPart={state.ui.highlighted_part || undefined} />
       </motion.div>
     </motion.div>


### PR DESCRIPTION
💡 **What:** Added `aria-label="Close"` to the icon-only `<button>` tags containing the Lucide `<X />` icon across 8 different modal components.
🎯 **Why:** To improve accessibility for screen reader users by providing a descriptive accessible name for close buttons that previously had none.
📸 **Before/After:** Not a visual change.
♿ **Accessibility:** Added accessible names to close buttons in `InventoryModal`, `JournalModal`, `MapModal`, `ShopModal`, `SocialModal`, `StatsModal`, `WardrobeModal`, and `XRayModal`.

---
*PR created automatically by Jules for task [9711047109059292219](https://jules.google.com/task/9711047109059292219) started by @romeytheAI*