### PR TITLE
feat: implement backbone simulation tick loop and robust logging (#59)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useReducer, createContext, useCallback, Component, Suspense } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { 
+import { CalendarDays, Hourglass,
   Heart, Wind, Moon, Settings, X, BookOpen, User, Map as MapIcon, 
   Shield, Sword, Zap, Droplets, AlertTriangle, Ghost, Sparkles, 
   Layers, ShoppingBag, Eye, EyeOff, Thermometer, Clock, Calendar, RefreshCw, Book,
@@ -700,6 +700,23 @@ Example: { "health": 50, "allure": 20 }`;
             >
               <Book className="w-4 h-4 text-white/40 group-hover:text-white/80" />
               <span className="text-[10px] tracking-widest uppercase text-white/50 group-hover:text-white/90">Journal</span>
+            </motion.button>
+            <motion.button
+              whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}
+              onClick={() => dispatch({ type: 'PASS_TIME', payload: { hours: 24 } })}
+              title="Debug: Pass 24 Hours (Sanity Test)"
+              className="group flex items-center gap-2 px-3 py-1.5 border border-red-500/20 hover:border-red-500/50 bg-red-900/10 transition-all rounded-sm ml-2"
+            >
+              <CalendarDays className="w-4 h-4 text-red-400/50 group-hover:text-red-400/90" />
+              <span className="text-[10px] tracking-widest uppercase text-red-400/60 group-hover:text-red-400">Pass Day</span>
+            </motion.button>
+            <motion.button
+              whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}
+              onClick={() => dispatch({ type: 'PASS_TIME', payload: { hours: 1 } })}
+              className="group flex items-center gap-2 px-3 py-1.5 border border-white/10 hover:border-white/30 transition-all rounded-sm"
+            >
+              <Hourglass className="w-4 h-4 text-emerald-400/40 group-hover:text-emerald-400/80" />
+              <span className="text-[10px] tracking-widest uppercase text-white/50 group-hover:text-white/90">Pass Time</span>
             </motion.button>
             <motion.button 
               whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}

--- a/src/reducers/gameReducer.ts
+++ b/src/reducers/gameReducer.ts
@@ -605,7 +605,11 @@ export function gameReducer(state: GameState, action: any): GameState {
       // 16. Tick simulation engine if available
       let nextSimWorld = state.sim_world;
       if (nextSimWorld) {
+        console.time('SimTick:RESOLVE_TEXT');
+        const prevTickTurn = nextSimWorld.turn;
         nextSimWorld = tickSimulation(nextSimWorld);
+        console.timeEnd('SimTick:RESOLVE_TEXT');
+        console.debug(`[SimTick] Turn advanced: ${prevTickTurn} -> ${nextSimWorld.turn}`);
       }
 
       const basePlayer = {
@@ -962,10 +966,49 @@ export function gameReducer(state: GameState, action: any): GameState {
         }
       };
 
+    case 'PASS_TIME': {
+      const hoursPassed = action.payload?.hours || 1;
+
+      const newWorld = { ...state.world };
+      const previousDay = newWorld.day;
+      newWorld.hour += hoursPassed;
+      while (newWorld.hour >= 24) {
+        newWorld.hour -= 24;
+        newWorld.day += 1;
+        newWorld.week_day = advanceWeekDay(newWorld.week_day, 1);
+      }
+
+      let nextSimWorld = state.sim_world;
+      if (nextSimWorld) {
+        console.time('SimTick:PASS_TIME');
+        for (let i = 0; i < hoursPassed; i++) {
+            nextSimWorld = tickSimulation(nextSimWorld);
+        }
+        console.timeEnd('SimTick:PASS_TIME');
+        console.debug(`[SimTick:PASS_TIME] Advanced ${hoursPassed} hours to turn ${nextSimWorld.turn}`);
+      }
+
+      return {
+        ...state,
+        world: newWorld,
+        sim_world: nextSimWorld,
+        ui: {
+            ...state.ui,
+            currentLog: [
+                ...state.ui.currentLog,
+                { text: `You wait for ${hoursPassed} hour${hoursPassed > 1 ? 's' : ''}.`, type: 'narrative' }
+            ]
+        }
+      };
+    }
+
     // ── Simulation engine ────────────────────────────────────────────────
     case 'SIM_TICK': {
       if (!state.sim_world) return state;
+      console.time('SimTick:MANUAL');
       const nextSimWorld: SimWorld = tickSimulation(state.sim_world);
+      console.timeEnd('SimTick:MANUAL');
+      console.debug(`[SimTick:MANUAL] Turn advanced to ${nextSimWorld.turn}`);
       return { ...state, sim_world: nextSimWorld };
     }
 


### PR DESCRIPTION
resolves #59

- Add console.time and console.debug logging around the tickSimulation call in RESOLVE_TEXT to measure the tick duration and log game state changes.
- Add a new PASS_TIME reducer case that manages advancing hour, day and week_day and explicitly ticks the simulation by hoursPassed.
- Implement 'Pass Time' and 'Pass Day' debug/interaction buttons in the UI to let the user sanity-test and trigger the ticking loop directly.

---
*PR created automatically by Jules for task [14278157087621114975](https://jules.google.com/task/14278157087621114975) started by @romeytheAI*