### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -784,6 +784,7 @@ Example: { "health": 50, "allure": 20 }`;
             )}
             
             <button 
+              aria-label="Open settings"
               onClick={() => setShowSettings(true)}
               className="p-2 hover:bg-white/5 rounded-full transition-colors group"
             >
@@ -1129,7 +1130,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Journal" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_quests', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Journal</h2>
               
               <div className="space-y-6">
@@ -1194,7 +1195,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_map', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Map" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_map', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Cartography of Tamriel</h2>
               
               <div className="grid grid-cols-3 gap-8">
@@ -1310,7 +1311,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.95, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.95, opacity: 0 }}
               className="max-w-2xl w-full relative"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
+              <button aria-label="Close X-Ray view" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_xray', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white z-10"><X className="w-6 h-6" /></button>
               <Suspense fallback={<ChunkFallback />}><XRayView anatomy={state.player.anatomy} highlightedPart={state.ui.highlighted_part || undefined} /></Suspense>
             </motion.div>
           </motion.div>
@@ -1353,7 +1354,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Character Stats" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_stats', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Character Essence</h2>
               
               <div className="grid grid-cols-2 gap-8">
@@ -1556,7 +1557,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Inventory" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Possessions</h2>
               
               <div className="grid grid-cols-3 gap-8">
@@ -1697,7 +1698,7 @@ Example: { "health": 50, "allure": 20 }`;
               onClick={(e) => e.stopPropagation()}
               className="bg-[#0a0a0a] border border-amber-900/30 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Item Details" onClick={() => setSelectedItem(null)} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               
               <div className="flex items-center gap-3 mb-6 border-b border-white/10 pb-4">
                 <h2 className="text-2xl font-serif text-amber-500/90 tracking-widest uppercase">{selectedItem.name}</h2>
@@ -1858,6 +1859,7 @@ Example: { "health": 50, "allure": 20 }`;
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[80vh] z-10"
             >
               <button 
+                aria-label="Close Companions"
                 onClick={() => setShowCompanions(false)}
                 className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -784,7 +784,7 @@ Example: { "health": 50, "allure": 20 }`;
             )}
             
             <button 
-              aria-label="Open settings"
+              aria-label="Open Settings"
               onClick={() => setShowSettings(true)}
               className="p-2 hover:bg-white/5 rounded-full transition-colors group"
             >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1557,7 +1557,7 @@ Example: { "health": 50, "allure": 20 }`;
               initial={{ scale: 0.9, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.9, opacity: 0 }}
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-4xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
             >
-              <button aria-label="Close Inventory" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
+              <button aria-label="Close Possessions" onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_inventory', value: false } })} className="absolute top-6 right-6 text-white/40 hover:text-white"><X className="w-6 h-6" /></button>
               <h2 className="text-2xl font-serif text-white/90 mb-8 border-b border-white/10 pb-4 tracking-widest uppercase">Possessions</h2>
               
               <div className="grid grid-cols-3 gap-8">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1859,7 +1859,7 @@ Example: { "health": 50, "allure": 20 }`;
               className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[80vh] z-10"
             >
               <button 
-                aria-label="Close Companions"
+                aria-label="Close Companion Roster"
                 onClick={() => setShowCompanions(false)}
                 className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
               >

--- a/src/components/ImmersiveStartMenu.tsx
+++ b/src/components/ImmersiveStartMenu.tsx
@@ -455,6 +455,7 @@ export const ImmersiveStartMenu: React.FC<ImmersiveStartMenuProps> = ({ onStartG
                               <Upload className="w-4 h-4" />
                             </button>
                             <button 
+                              aria-label={`Delete save ${save.name} (Hold to confirm)`}
                               className="p-2 hover:bg-red-900/50 text-white/40 hover:text-red-400 transition-colors" 
                               title="Delete Save (Hold)"
                               onMouseDown={(e) => {

--- a/src/components/ImmersiveStartMenu.tsx
+++ b/src/components/ImmersiveStartMenu.tsx
@@ -457,7 +457,7 @@ export const ImmersiveStartMenu: React.FC<ImmersiveStartMenuProps> = ({ onStartG
                             <button 
                               aria-label={`Delete save ${save.name} (Hold to confirm)`}
                               className="p-2 hover:bg-red-900/50 text-white/40 hover:text-red-400 transition-colors" 
-                              title="Delete Save (Hold)"
+                              title={`Delete save ${save.name} (Hold to confirm)`}
                               onMouseDown={(e) => {
                                 const timer = setTimeout(() => handleDeleteSave(save.id), 2000);
                                 e.currentTarget.onmouseup = () => clearTimeout(timer);

--- a/src/components/modals/DeveloperModeModal.tsx
+++ b/src/components/modals/DeveloperModeModal.tsx
@@ -52,6 +52,7 @@ export const DeveloperModeModal: React.FC<DeveloperModeModalProps> = ({ state, d
         className="bg-[#0a0a0a] border border-purple-500/20 p-8 rounded-sm max-w-2xl w-full relative shadow-[0_0_50px_rgba(168,85,247,0.1)] z-10"
       >
         <button 
+          aria-label="Close Developer Mode"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/FeatsModal.tsx
+++ b/src/components/modals/FeatsModal.tsx
@@ -47,6 +47,7 @@ export const FeatsModal: React.FC<FeatsModalProps> = ({ state, dispatch }) => {
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-lg w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
         <button
+          aria-label="Close Feats"
           onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_feats', value: false } })}
           className="absolute top-6 right-6 text-white/40 hover:text-white"
         >

--- a/src/components/modals/MemoriesModal.tsx
+++ b/src/components/modals/MemoriesModal.tsx
@@ -49,6 +49,7 @@ export const MemoriesModal: React.FC<MemoriesModalProps> = ({ state, onClose }) 
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full max-h-[80vh] flex flex-col relative shadow-2xl z-10"
       >
         <button 
+          aria-label="Close Memories"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -65,6 +65,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-md w-full relative shadow-2xl z-10 max-h-[90vh] overflow-y-auto scrollbar-hide"
       >
         <button 
+          aria-label="Close Settings"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/StatusModal.tsx
+++ b/src/components/modals/StatusModal.tsx
@@ -52,7 +52,7 @@ export const StatusModal: React.FC<StatusModalProps> = ({ state, onClose }) => {
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-md w-full relative shadow-2xl z-10"
       >
         <button 
-          aria-label="Close Status"
+          aria-label="Close Physiological Matrix"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/StatusModal.tsx
+++ b/src/components/modals/StatusModal.tsx
@@ -52,6 +52,7 @@ export const StatusModal: React.FC<StatusModalProps> = ({ state, onClose }) => {
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-md w-full relative shadow-2xl z-10"
       >
         <button 
+          aria-label="Close Status"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/TraitsModal.tsx
+++ b/src/components/modals/TraitsModal.tsx
@@ -58,6 +58,7 @@ export const TraitsModal: React.FC<TraitsModalProps> = ({ state, dispatch }) => 
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full relative shadow-2xl overflow-y-auto max-h-[90vh] z-10"
       >
         <button
+          aria-label="Close Traits"
           onClick={() => dispatch({ type: 'TOGGLE_UI_SETTING', payload: { key: 'show_traits', value: false } })}
           className="absolute top-6 right-6 text-white/40 hover:text-white"
         >
@@ -226,6 +227,7 @@ export const TraitsModal: React.FC<TraitsModalProps> = ({ state, dispatch }) => 
                     )}
                   </div>
                   <button
+                    aria-label={`Remove trait ${trait.name}`}
                     onClick={() => dispatch({ type: 'REMOVE_TRAIT', payload: trait.id })}
                     className="text-white/20 hover:text-red-400 transition-colors shrink-0 ml-2"
                     title="Remove trait"

--- a/src/components/modals/TraitsModal.tsx
+++ b/src/components/modals/TraitsModal.tsx
@@ -230,7 +230,7 @@ export const TraitsModal: React.FC<TraitsModalProps> = ({ state, dispatch }) => 
                     aria-label={`Remove trait ${trait.name}`}
                     onClick={() => dispatch({ type: 'REMOVE_TRAIT', payload: trait.id })}
                     className="text-white/20 hover:text-red-400 transition-colors shrink-0 ml-2"
-                    title="Remove trait"
+                    title={`Remove trait ${trait.name}`}
                   >
                     <Trash2 className="w-3.5 h-3.5" />
                   </button>


### PR DESCRIPTION
💡 **What:**
Added descriptive `aria-label` attributes to roughly 15 icon-only buttons across the application's UI. This includes the main settings button, side panel close buttons, modal close buttons, and list item action buttons (like deleting a save or removing a trait).

🎯 **Why:**
Icon-only buttons rely entirely on visual context to convey their meaning. Users utilizing assistive technologies, such as screen readers, cannot see these icons and depend on text alternatives. Without an `aria-label` (or similar accessible name), screen readers will often just announce "button", leaving the user completely unaware of what the button does. This is a crucial accessibility fix.

📸 **Before/After:**
*(No visual changes - purely a markup/accessibility improvement)*

♿ **Accessibility:**
- Improved screen reader navigation and comprehension for modal dialogs and side panels.
- Users can now confidently identify destructive actions (like deleting a save or trait) without relying on visual cues alone.
- Ensured dynamic labels were used where appropriate (e.g., `aria-label="Remove trait ${trait.name}"`) to provide maximum context.

---
*PR created automatically by Jules for task [7402146448230277163](https://jules.google.com/task/7402146448230277163) started by @romeytheAI*