### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure Math.random fallback for UUIDs

### DIFF
--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,6 +1,6 @@
 /**
- * Generates a cryptographically secure UUID v4 if available,
- * otherwise falls back to a pseudo-random UUID.
+ * Generates a cryptographically secure UUID v4 if available.
+ * Throws an error if no secure random generation is supported.
  */
 export function generateId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -12,21 +12,12 @@ export function generateId(): string {
   }
 
   if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
-    try {
-      return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-        const r = crypto.getRandomValues(new Uint8Array(1))[0] & 15;
-        const v = c === 'x' ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      });
-    } catch (e) {
-      // Fallback to Math.random if getRandomValues fails
-    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+      const r = crypto.getRandomValues(new Uint8Array(1))[0] & 15;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
   }
 
-  // Standard UUID v4 fallback
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  throw new Error("Secure random number generation is not supported in this environment. Cannot generate secure UUIDs.");
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `src/utils/crypto.ts` used `Math.random()` to generate UUIDs if `crypto.randomUUID` or `crypto.getRandomValues` failed. `Math.random()` is not cryptographically secure, leading to predictable IDs that could be exploited if used for sensitive tokens or sessions.
🎯 Impact: Attackers could potentially predict UUIDs generated by the application, leading to session hijacking or unauthorized access if these IDs are used for security-critical functions.
🔧 Fix: Removed the `Math.random()` fallback. The application now fails securely by throwing an Error if no secure random generation is supported, preventing the creation of weak IDs.
✅ Verification: Ran `pnpm test` successfully. Verified that no tests relied on the weak fallback.

---
*PR created automatically by Jules for task [4900294809848176663](https://jules.google.com/task/4900294809848176663) started by @romeytheAI*