### PR TITLE
🎨 Palette: [SettingsModal] WAI-ARIA compliance and keyboard focus for toggles and buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-15 - Adding ARIA Labels to Lucide Icons in Modals
 **Learning:** When using Lucide React icons within buttons for modals, they are inherently inaccessible to screen readers without an explicit aria-label on the parent button tag. This is a common pattern in this project's modals.
 **Action:** Always verify that icon-only buttons in new components, particularly modals, are provided with a descriptive aria-label.
+
+## 2024-05-18 - Custom UI Toggle Switches WAI-ARIA Compliance
+**Learning:** When implementing custom UI toggle switches (e.g., using `div` or `button` elements instead of `<input type="checkbox">`), they must be marked up with WAI-ARIA attributes (`role="switch"`, `aria-checked={active}`) to ensure screen readers can understand and interact with them properly.
+**Action:** Always add appropriate roles and aria-checked attributes when creating custom toggles to maintain accessibility.

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -39,7 +39,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             <Settings className="w-5 h-5 text-sky-400" />
             <h2 className="text-xl font-serif tracking-widest uppercase text-white/90">System Configuration</h2>
           </div>
-          <button onClick={onClose} className="p-2 hover:bg-white/5 rounded-sm transition-colors text-white/40 hover:text-white">
+          <button aria-label="Close settings" onClick={onClose} className="p-2 hover:bg-white/5 rounded-sm transition-colors text-white/40 hover:text-white focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none">
             <X className="w-6 h-6" />
           </button>
         </div>
@@ -72,7 +72,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
         </div>
 
         <div className="p-6 border-t border-white/5 bg-black/40 flex justify-end gap-4">
-           <button onClick={() => saveGame('manual', state)} className="px-8 py-3 bg-sky-500/10 border border-sky-500/30 text-sky-400 text-[10px] tracking-[0.3em] uppercase font-bold hover:bg-sky-500/20 transition-all rounded-sm">
+           <button onClick={() => saveGame('manual', state)} className="px-8 py-3 bg-sky-500/10 border border-sky-500/30 text-sky-400 text-[10px] tracking-[0.3em] uppercase font-bold hover:bg-sky-500/20 transition-all rounded-sm focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none">
              Commit State to Disk
            </button>
         </div>
@@ -93,8 +93,14 @@ const Section: React.FC<{ title: string; icon: React.ReactNode; children: React.
 
 const Toggle: React.FC<{ label: string; active: boolean; onClick: () => void }> = ({ label, active, onClick }) => (
   <div className="flex items-center justify-between group">
-    <span className="text-xs text-white/40 group-hover:text-white/70 transition-colors">{label}</span>
-    <button onClick={onClick} className={`w-10 h-5 rounded-full relative transition-colors ${active ? 'bg-sky-500' : 'bg-white/10'}`}>
+    <span aria-hidden="true" className="text-xs text-white/40 group-hover:text-white/70 transition-colors">{label}</span>
+    <button
+      role="switch"
+      aria-checked={active}
+      aria-label={label}
+      onClick={onClick}
+      className={`w-10 h-5 rounded-full relative transition-colors focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none ${active ? 'bg-sky-500' : 'bg-white/10'}`}
+    >
       <motion.div animate={{ x: active ? 22 : 2 }} className="absolute top-1 left-0 w-3 h-3 bg-white rounded-full shadow-lg" />
     </button>
   </div>


### PR DESCRIPTION
💡 **What:** 
- Added `role="switch"` and `aria-checked` to the custom toggle components.
- Hidden the redundant visual label for toggles from screen readers using `aria-hidden="true"`.
- Added visible focus rings (`focus-visible:ring-2`) to all interactive elements (Toggles, Close button, Save button).
- Added `aria-label="Close settings"` to the icon-only exit button.

🎯 **Why:** 
To ensure the settings modal is fully navigable via keyboard and properly announced by screen readers, preventing "dead" unlabelled interaction points.

📸 **Before/After:**
*(Visual changes restricted to outline rings on keyboard focus)*

♿ **Accessibility:**
- Custom UI switches now correctly report state to assistive technology.
- Icon-only button has context.
- Keyboard navigation is visually represented.

---
*PR created automatically by Jules for task [3777123417312907353](https://jules.google.com/task/3777123417312907353) started by @romeytheAI*