### PR TITLE
🧪 [testing improvement] Add edge case tests for gameLogic semantic helpers

### DIFF
--- a/src/utils/gameLogic.test.ts
+++ b/src/utils/gameLogic.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { getHealthSemantic, getStaminaSemantic, getTraumaSemantic } from './gameLogic';
+
+describe('gameLogic semantic helpers', () => {
+  describe('getHealthSemantic', () => {
+    it('returns "Robust" for values > 80', () => {
+      expect(getHealthSemantic(100)).toBe('Robust');
+      expect(getHealthSemantic(81)).toBe('Robust');
+    });
+
+    it('returns "Battered" for values between 51 and 80', () => {
+      expect(getHealthSemantic(80)).toBe('Battered');
+      expect(getHealthSemantic(79)).toBe('Battered');
+      expect(getHealthSemantic(51)).toBe('Battered');
+    });
+
+    it('returns "Bleeding" for values between 21 and 50', () => {
+      expect(getHealthSemantic(50)).toBe('Bleeding');
+      expect(getHealthSemantic(49)).toBe('Bleeding');
+      expect(getHealthSemantic(21)).toBe('Bleeding');
+    });
+
+    it('returns "Death\'s Door" for values <= 20', () => {
+      expect(getHealthSemantic(20)).toBe("Death's Door");
+      expect(getHealthSemantic(19)).toBe("Death's Door");
+      expect(getHealthSemantic(0)).toBe("Death's Door");
+    });
+  });
+
+  describe('getStaminaSemantic', () => {
+    it('returns "Energetic" for values > 80', () => {
+      expect(getStaminaSemantic(100)).toBe('Energetic');
+      expect(getStaminaSemantic(81)).toBe('Energetic');
+    });
+
+    it('returns "Winded" for values between 51 and 80', () => {
+      expect(getStaminaSemantic(80)).toBe('Winded');
+      expect(getStaminaSemantic(79)).toBe('Winded');
+      expect(getStaminaSemantic(51)).toBe('Winded');
+    });
+
+    it('returns "Exhausted" for values between 21 and 50', () => {
+      expect(getStaminaSemantic(50)).toBe('Exhausted');
+      expect(getStaminaSemantic(49)).toBe('Exhausted');
+      expect(getStaminaSemantic(21)).toBe('Exhausted');
+    });
+
+    it('returns "Collapsing" for values <= 20', () => {
+      expect(getStaminaSemantic(20)).toBe('Collapsing');
+      expect(getStaminaSemantic(19)).toBe('Collapsing');
+      expect(getStaminaSemantic(0)).toBe('Collapsing');
+    });
+  });
+
+  describe('getTraumaSemantic', () => {
+    it('returns "Lucid" for values < 20', () => {
+      expect(getTraumaSemantic(0)).toBe('Lucid');
+      expect(getTraumaSemantic(19)).toBe('Lucid');
+    });
+
+    it('returns "Shaken" for values between 20 and 49', () => {
+      expect(getTraumaSemantic(20)).toBe('Shaken');
+      expect(getTraumaSemantic(21)).toBe('Shaken');
+      expect(getTraumaSemantic(49)).toBe('Shaken');
+    });
+
+    it('returns "Disturbed" for values between 50 and 79', () => {
+      expect(getTraumaSemantic(50)).toBe('Disturbed');
+      expect(getTraumaSemantic(51)).toBe('Disturbed');
+      expect(getTraumaSemantic(79)).toBe('Disturbed');
+    });
+
+    it('returns "Fractured" for values >= 80', () => {
+      expect(getTraumaSemantic(80)).toBe('Fractured');
+      expect(getTraumaSemantic(81)).toBe('Fractured');
+      expect(getTraumaSemantic(100)).toBe('Fractured');
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Missing edge case tests for `gameLogic.ts` semantic helpers (`getHealthSemantic`, `getStaminaSemantic`, `getTraumaSemantic`).

📊 **Coverage:** 
- `getHealthSemantic`: Values > 80 (Robust), 51-80 (Battered), 21-50 (Bleeding), <= 20 (Death's Door).
- `getStaminaSemantic`: Values > 80 (Energetic), 51-80 (Winded), 21-50 (Exhausted), <= 20 (Collapsing).
- `getTraumaSemantic`: Values < 20 (Lucid), 20-49 (Shaken), 50-79 (Disturbed), >= 80 (Fractured).
- Tested exact boundary values (20, 50, 80) for each function.

✨ **Result:** Significant increase in reliability for player state display logic. The new test file `src/utils/gameLogic.test.ts` provides 100% path coverage for these semantic helpers.

---
*PR created automatically by Jules for task [12859886000374543147](https://jules.google.com/task/12859886000374543147) started by @romeytheAI*