### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to modal Close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,11 @@
+## 2024-05-15 - Adding ARIA Labels to Lucide Icons in Modals
+**Learning:** When using Lucide React icons within buttons for modals, they are inherently inaccessible to screen readers without an explicit aria-label on the parent button tag. This is a common pattern in this project's modals.
+**Action:** Always verify that icon-only buttons in new components, particularly modals, are provided with a descriptive aria-label.
+
+## 2024-05-18 - Custom UI Toggle Switches WAI-ARIA Compliance
+**Learning:** When implementing custom UI toggle switches (e.g., using `div` or `button` elements instead of `<input type="checkbox">`), they must be marked up with WAI-ARIA attributes (`role="switch"`, `aria-checked={active}`) to ensure screen readers can understand and interact with them properly.
+**Action:** Always add appropriate roles and aria-checked attributes when creating custom toggles to maintain accessibility.
+
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,7 +1,3 @@
-## 2024-05-15 - Adding ARIA Labels to Lucide Icons in Modals
-**Learning:** When using Lucide React icons within buttons for modals, they are inherently inaccessible to screen readers without an explicit aria-label on the parent button tag. This is a common pattern in this project's modals.
-**Action:** Always verify that icon-only buttons in new components, particularly modals, are provided with a descriptive aria-label.
-
-## 2024-05-18 - Custom UI Toggle Switches WAI-ARIA Compliance
-**Learning:** When implementing custom UI toggle switches (e.g., using `div` or `button` elements instead of `<input type="checkbox">`), they must be marked up with WAI-ARIA attributes (`role="switch"`, `aria-checked={active}`) to ensure screen readers can understand and interact with them properly.
-**Action:** Always add appropriate roles and aria-checked attributes when creating custom toggles to maintain accessibility.
+## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
+**Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
+**Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).

--- a/src/components/modals/DeveloperModeModal.tsx
+++ b/src/components/modals/DeveloperModeModal.tsx
@@ -52,6 +52,7 @@ export const DeveloperModeModal: React.FC<DeveloperModeModalProps> = ({ state, d
         className="bg-[#0a0a0a] border border-purple-500/20 p-8 rounded-sm max-w-2xl w-full relative shadow-[0_0_50px_rgba(168,85,247,0.1)] z-10"
       >
         <button 
+          aria-label="Close Developer Mode"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/MemoriesModal.tsx
+++ b/src/components/modals/MemoriesModal.tsx
@@ -49,6 +49,7 @@ export const MemoriesModal: React.FC<MemoriesModalProps> = ({ state, onClose }) 
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-2xl w-full max-h-[80vh] flex flex-col relative shadow-2xl z-10"
       >
         <button 
+          aria-label="Close Memories"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >

--- a/src/components/modals/StatusModal.tsx
+++ b/src/components/modals/StatusModal.tsx
@@ -52,6 +52,7 @@ export const StatusModal: React.FC<StatusModalProps> = ({ state, onClose }) => {
         className="bg-[#0a0a0a] border border-white/10 p-8 rounded-sm max-w-md w-full relative shadow-2xl z-10"
       >
         <button 
+          aria-label="Close Status"
           onClick={onClose}
           className="absolute top-6 right-6 text-white/40 hover:text-white transition-colors"
         >


### PR DESCRIPTION
💡 What: Added descriptive `aria-label` attributes to the "Close" icon-only buttons (`<X>`) within the `DeveloperModeModal`, `MemoriesModal`, and `StatusModal`. Also updated the `.Jules/palette.md` journal with this critical learning.

🎯 Why: Icon-only buttons without an explicit text alternative (like an `aria-label`) are completely opaque to screen readers, meaning visually impaired users wouldn't know the button's purpose is to close the modal. This improves the overall accessibility of the application.

📸 Before/After: Visuals are unchanged. The underlying DOM now features `aria-label="Close Developer Mode"`, `aria-label="Close Memories"`, and `aria-label="Close Status"`.

♿ Accessibility: Ensures that screen readers can correctly identify and announce the "Close" action for modal dialogs.

---
*PR created automatically by Jules for task [7051454048498898628](https://jules.google.com/task/7051454048498898628) started by @romeytheAI*