### PR TITLE
feat: add devcontainer and Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Node.js 22",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000],
+
+  // Use 'updateContentCommand' or 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "npm i -g pnpm && pnpm install",
+
+  // Expose environment variables to the container
+  "containerEnv": {
+    "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,14 +10,25 @@ View your app in AI Studio: https://ai.studio/apps/c27ece4c-b654-4b65-a8ce-77dae
 
 ## Run Locally
 
-**Prerequisites:**  Node.js
+**Prerequisites:** Node.js 22
 
+The repository uses `pnpm` exclusively. Never use `npm` or `yarn`.
 
 1. Install dependencies:
-   `npm install`
+   `pnpm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
-   `npm run dev`
+   `pnpm run dev`
+
+## GitHub Codespaces / Devcontainer
+
+This repository supports GitHub Codespaces and devcontainers out of the box, providing a standardized Node.js 22 environment with `pnpm` pre-installed.
+
+1. **Launch a Codespace**: Click the "Code" button on GitHub and select "Create codespace on main".
+2. **Environment Variables**: To use the Gemini features, you need to expose your API key. In your GitHub Settings -> Codespaces -> Codespaces secrets, add a new secret named `GEMINI_API_KEY` with your API key, and assign it to this repository. The devcontainer will automatically pick this up.
+3. Once the Codespace starts, all dependencies will be automatically installed via `pnpm install`, and you can start the development server by running:
+   `pnpm run dev`
+   (Port 3000 will be automatically forwarded).
 
 ## Foundation roadmap
 


### PR DESCRIPTION
This PR addresses the `[MaxVP][P0] Codespaces + devcontainer parity` issue by establishing a `.devcontainer` configuration. This ensures developers and agents operate in an identical, stable Node 22 environment out of the box with port 3000 forwarded and dependencies installed via `pnpm`.

### What changed
- Created `.devcontainer/devcontainer.json`.
- Configured local environment variable passing for `GEMINI_API_KEY`.
- Updated `README.md` to reflect `pnpm` exclusively and document Codespace instructions.

---
*PR created automatically by Jules for task [6423141620017018371](https://jules.google.com/task/6423141620017018371) started by @romeytheAI*