### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to color swatches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).
+
+## 2024-05-18 - Missing ARIA Labels on Color Swatches
+**Learning:** When implementing color swatches (e.g., skin, eye, or hair color selection) as empty `<button>` tags relying on CSS `backgroundColor` for visual representation, they are invisible to screen readers without an explicit name.
+**Action:** Always provide explicit `aria-label` and `title` attributes (e.g., `aria-label="Select skin tone [color]"`) to empty color swatch buttons to maintain accessibility for screen readers and provide tooltip context.

--- a/src/components/modals/CharacterCreationModal.tsx
+++ b/src/components/modals/CharacterCreationModal.tsx
@@ -168,6 +168,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
             {raceDef.skin_colors.map(color => (
               <button 
                 key={color}
+                aria-label={`Select skin tone ${color}`}
+                title={`Skin tone ${color}`}
                 onClick={() => setSkinTone(color)}
                 style={{ backgroundColor: color }}
                 className={`w-10 h-10 rounded-sm border-2 transition-all ${skinTone === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
@@ -181,6 +183,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
             {raceDef.eye_colors.map(color => (
               <button 
                 key={color}
+                aria-label={`Select eye color ${color}`}
+                title={`Eye color ${color}`}
                 onClick={() => setEyeColor(color)}
                 style={{ backgroundColor: color }}
                 className={`w-10 h-10 rounded-full border-2 transition-all ${eyeColor === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
@@ -196,6 +200,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
             {raceDef.hair_colors.map(color => (
               <button 
                 key={color}
+                aria-label={`Select hair color ${color}`}
+                title={`Hair color ${color}`}
                 onClick={() => setHairColor(color)}
                 style={{ backgroundColor: color }}
                 className={`w-8 h-8 rounded-sm border-2 transition-all ${hairColor === color ? 'border-sky-400 scale-110' : 'border-transparent opacity-40 hover:opacity-100'}`}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the color selection buttons (skin, eye, and hair colors) in the Character Creation Modal.
🎯 Why: Empty `<button>` elements that rely solely on inline `backgroundColor` styles for visual representation are inaccessible to screen reader users (as they have no text content) and lack context on hover for sighted users.
📸 Before/After: Visual changes are only tooltips on hover. Screen readers will now announce the button purpose (e.g., "Select skin tone fair").
♿ Accessibility: Improves WAI-ARIA compliance for interactive elements by ensuring all buttons have an accessible name.

I have also updated `.Jules/palette.md` to record the accessibility pattern. Linting and testing passed successfully.

---
*PR created automatically by Jules for task [9164659376943385562](https://jules.google.com/task/9164659376943385562) started by @romeytheAI*