### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to color swatch buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).
+
+## 2024-05-18 - Missing ARIA Labels on Color Swatch Buttons
+**Learning:** When color swatches are implemented as empty `<button>` tags that rely solely on CSS `backgroundColor` for visual representation, they are completely invisible to screen readers without an explicit `aria-label`.
+**Action:** Always provide `aria-label` and `title` attributes on empty button elements used for color selection to ensure they are accessible.

--- a/src/components/modals/CharacterCreationModal.tsx
+++ b/src/components/modals/CharacterCreationModal.tsx
@@ -169,6 +169,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
               <button 
                 key={color}
                 onClick={() => setSkinTone(color)}
+                aria-label={`Select skin tone ${color}`}
+                title={`Skin tone ${color}`}
                 style={{ backgroundColor: color }}
                 className={`w-10 h-10 rounded-sm border-2 transition-all ${skinTone === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />
@@ -182,6 +184,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
               <button 
                 key={color}
                 onClick={() => setEyeColor(color)}
+                aria-label={`Select eye color ${color}`}
+                title={`Eye color ${color}`}
                 style={{ backgroundColor: color }}
                 className={`w-10 h-10 rounded-full border-2 transition-all ${eyeColor === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />
@@ -197,6 +201,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
               <button 
                 key={color}
                 onClick={() => setHairColor(color)}
+                aria-label={`Select hair color ${color}`}
+                title={`Hair color ${color}`}
                 style={{ backgroundColor: color }}
                 className={`w-8 h-8 rounded-sm border-2 transition-all ${hairColor === color ? 'border-sky-400 scale-110' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />


### PR DESCRIPTION
💡 **What:** Added `aria-label` and `title` attributes to empty `<button>` color swatches (skin tone, eye color, hair color) in `CharacterCreationModal.tsx`. Also documented this learning in `.Jules/palette.md`.

🎯 **Why:** To improve accessibility. Because these buttons have no text content and rely only on inline `backgroundColor` styles for their visual representation, screen readers had no way to announce them to users.

📸 **Before/After:** No visual change.

♿ **Accessibility:** Screen readers can now correctly read and describe what each color swatch button represents (e.g., "Select skin tone fair"), allowing visually impaired users to interact meaningfully with the character creation process. Tooltips (`title`) also assist mouse users by indicating exactly what color is being hovered.

---
*PR created automatically by Jules for task [1525248218040087328](https://jules.google.com/task/1525248218040087328) started by @romeytheAI*