### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to color swatches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).
+
+## 2024-05-18 - Missing ARIA Labels on Color Swatches
+**Learning:** In the project's character creation modal, color swatches (skin, eye, hair) are implemented as `<button>` elements that rely solely on inline CSS `backgroundColor` for visual representation. They lack textual content, making them inaccessible to screen readers without an explicit `aria-label`.
+**Action:** Always provide `aria-label` and `title` attributes when implementing empty `<button>` elements that act as color swatches to ensure they are accessible and have a hover tooltip.

--- a/.github/workflows/jules-conflict-resolver.yml
+++ b/.github/workflows/jules-conflict-resolver.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Invoke Jules for Resolution
         if: steps.conflict-check.outputs.has_conflicts == 'true'
-        uses: google-labs-code/jules-invoke@v1
+        uses: google-labs-code/jules-invoke@v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |

--- a/.github/workflows/jules-conflict-resolver.yml
+++ b/.github/workflows/jules-conflict-resolver.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Invoke Jules for Resolution
         if: steps.conflict-check.outputs.has_conflicts == 'true'
-        uses: google-labs-code/jules-invoke@v1.0.0
+        uses: google-labs-code/jules-invoke@v1
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |

--- a/.github/workflows/jules-issue-resolver.yml
+++ b/.github/workflows/jules-issue-resolver.yml
@@ -27,7 +27,7 @@ jobs:
             })
 
       - name: Invoke Jules
-        uses: google-labs-code/jules-invoke@v1
+        uses: google-labs-code/jules-invoke@v1.0.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |

--- a/.github/workflows/jules-issue-resolver.yml
+++ b/.github/workflows/jules-issue-resolver.yml
@@ -27,7 +27,7 @@ jobs:
             })
 
       - name: Invoke Jules
-        uses: google-labs-code/jules-invoke@v1.0.0
+        uses: google-labs-code/jules-invoke@v1
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           prompt: |

--- a/src/components/modals/CharacterCreationModal.tsx
+++ b/src/components/modals/CharacterCreationModal.tsx
@@ -170,6 +170,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
                 key={color}
                 onClick={() => setSkinTone(color)}
                 style={{ backgroundColor: color }}
+                aria-label={`Select skin tone ${color}`}
+                title={`Select skin tone ${color}`}
                 className={`w-10 h-10 rounded-sm border-2 transition-all ${skinTone === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />
             ))}
@@ -183,6 +185,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
                 key={color}
                 onClick={() => setEyeColor(color)}
                 style={{ backgroundColor: color }}
+                aria-label={`Select eye color ${color}`}
+                title={`Select eye color ${color}`}
                 className={`w-10 h-10 rounded-full border-2 transition-all ${eyeColor === color ? 'border-sky-400 scale-110 shadow-[0_0_15px_rgba(14,165,233,0.5)]' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />
             ))}
@@ -198,6 +202,8 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
                 key={color}
                 onClick={() => setHairColor(color)}
                 style={{ backgroundColor: color }}
+                aria-label={`Select hair color ${color}`}
+                title={`Select hair color ${color}`}
                 className={`w-8 h-8 rounded-sm border-2 transition-all ${hairColor === color ? 'border-sky-400 scale-110' : 'border-transparent opacity-40 hover:opacity-100'}`}
               />
             ))}


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the color swatch buttons in the Character Creation modal.
🎯 Why: The color swatches are implemented as empty `<button>` elements with inline `backgroundColor` styles. Without text content or ARIA labels, screen readers cannot announce what these buttons do, making character customization inaccessible for some users. The `title` attribute also provides a helpful native tooltip on hover.
📸 Before/After: N/A (Visual appearance is unchanged, tooltip added).
♿ Accessibility: Improves screen reader compatibility by explicitly labeling skin tone, eye color, and hair color options.

---
*PR created automatically by Jules for task [18258040151751764615](https://jules.google.com/task/18258040151751764615) started by @romeytheAI*