### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,6 @@
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).
+## 2025-02-27 - Icon-Only Button ARIA Labels
+**Learning:** Reusable UX pattern found: Icon-only buttons (like the `Send` custom action button in `NarrativePanel` and target body part buttons in `EncounterUI`) must have explicit `aria-label`s and `title`s to be accessible to screen readers and mouse users.
+**Action:** Always ensure any `<button>` wrapping only a generic icon (like a Lucide icon or dynamic text representation) includes an `aria-label` describing its function. Use the same text for `title` if a visible tooltip is beneficial.

--- a/src/components/EncounterUI.tsx
+++ b/src/components/EncounterUI.tsx
@@ -203,6 +203,8 @@ export const EncounterUI: React.FC<EncounterUIProps> = React.memo(({ encounter, 
           <button
             key={part}
             onClick={() => setTargetedPart(part === targetedPart ? null : part)}
+            aria-label={"Target " + part}
+            title={"Target " + part}
             className={`text-[9px] uppercase tracking-widest p-1 border ${part === targetedPart ? 'bg-red-900 text-white' : 'border-red-900/30 text-red-500/50'}`}
           >
             {part}

--- a/src/components/NarrativePanel.tsx
+++ b/src/components/NarrativePanel.tsx
@@ -113,6 +113,7 @@ export const NarrativePanel: React.FC<NarrativePanelProps> = React.memo(({
               onKeyDown={(e) => e.key === 'Enter' && customAction && handleAction(customAction, 'custom')}
             />
             <button 
+              aria-label="Send custom action"
               onClick={() => customAction && handleAction(customAction, 'custom')}
               className="absolute right-4 text-white/20 hover:text-sky-400 transition-colors"
             >


### PR DESCRIPTION
💡 What: Added `aria-label`s to the icon-only submit button in `NarrativePanel` and tooltips (`aria-label` + `title`) to target selection buttons in `EncounterUI`.
🎯 Why: Enhances screen reader accessibility and provides tooltip hints for icon-only and abbreviation buttons, ensuring the interface is intuitive and fully usable for all users.
📸 Before/After: N/A (Non-visual DOM structure change).
♿ Accessibility: Increased a11y support for screen reader interactions and improved hover context for targeting buttons.

---
*PR created automatically by Jules for task [15969113399650655713](https://jules.google.com/task/15969113399650655713) started by @romeytheAI*