### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to inputs and textareas

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2024-05-18 - Missing ARIA Labels on Icon-Only Buttons
 **Learning:** In the project's modals, icon-only buttons (like those using the Lucide `<X>` icon for closing) frequently lack accessible names. This creates barriers for screen reader users who cannot visually determine the button's purpose.
 **Action:** Always verify that `<button>` tags containing only `<svg>` or icon components have a descriptive `aria-label` attribute (e.g., `aria-label="Close Modal"`).
+
+## 2024-05-25 - Redundant ARIA Labels
+**Learning:** Adding `aria-label`s to buttons that already have clear textual content (e.g. `<span>Gallery</span>`) is redundant and goes against best practices, as the screen reader will already read the button text. The focus should be strictly on inputs without associated labels and buttons that are purely iconic.
+**Action:** Always verify if a button has visible textual content before adding an `aria-label`. Only add `aria-label` to icon-only buttons or when the visible text is not sufficiently descriptive.

--- a/src/components/ImmersiveStartMenu.tsx
+++ b/src/components/ImmersiveStartMenu.tsx
@@ -404,6 +404,7 @@ export const ImmersiveStartMenu: React.FC<ImmersiveStartMenuProps> = React.memo(
                   <div className="mt-4">
                     <label className="text-xs tracking-widest uppercase text-white/40 block mb-2">World Seed (Optional)</label>
                     <input 
+                      aria-label="World Seed"
                       type="text" 
                       value={seedString}
                       onChange={(e) => setSeedString(e.target.value)}
@@ -521,6 +522,7 @@ export const ImmersiveStartMenu: React.FC<ImmersiveStartMenuProps> = React.memo(
                       <h3 className="text-xs tracking-widest uppercase text-white/40 mb-4">API Configuration</h3>
                       <div className="flex gap-2 mb-2">
                         <input 
+                          aria-label="API Key"
                           type="password" 
                           value={apiKey}
                           onChange={(e) => setApiKey(e.target.value)}
@@ -541,6 +543,7 @@ export const ImmersiveStartMenu: React.FC<ImmersiveStartMenuProps> = React.memo(
                     <div className="p-4 bg-white/5 border border-white/10">
                       <h3 className="text-xs tracking-widest uppercase text-white/40 mb-4">Model Sandbox Tester</h3>
                       <textarea 
+                        aria-label="Sandbox Prompt"
                         value={sandboxPrompt}
                         onChange={(e) => setSandboxPrompt(e.target.value)}
                         placeholder="Enter a test prompt..."

--- a/src/components/NarrativePanel.tsx
+++ b/src/components/NarrativePanel.tsx
@@ -105,6 +105,7 @@ export const NarrativePanel: React.FC<NarrativePanelProps> = React.memo(({
           <div className="absolute inset-0 bg-sky-500/5 rounded-lg blur-xl opacity-0 group-focus-within:opacity-100 transition-opacity" />
           <div className="relative flex items-center">
             <input 
+              aria-label="Directive to fate"
               type="text"
               value={customAction}
               onChange={(e) => setCustomAction(e.target.value)}

--- a/src/components/modals/CharacterCreationModal.tsx
+++ b/src/components/modals/CharacterCreationModal.tsx
@@ -102,6 +102,7 @@ export const CharacterCreationModal: React.FC<CharacterCreationModalProps> = ({ 
         <div className="relative group">
            <div className="absolute inset-0 bg-sky-500/5 blur-xl group-focus-within:bg-sky-500/10 transition-colors" />
            <input 
+             aria-label="Character Name"
              type="text" 
              value={name} 
              onChange={e => setName(e.target.value)}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -62,6 +62,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
                <div className="space-y-2">
                  <label className="text-[10px] tracking-widest uppercase text-white/30 block">Text Synthesis API Key</label>
                  <input 
+                   aria-label="Text Synthesis API Key"
                    type="password" value={state.ui.apiKey} 
                    onChange={(e) => dispatch({ type: 'SET_UI_SETTING', payload: { key: 'apiKey', value: e.target.value } })}
                    className="w-full bg-white/5 border border-white/10 p-2 rounded-sm text-xs font-mono text-white/60 focus:border-sky-500/40 outline-none"
@@ -113,6 +114,7 @@ const Slider: React.FC<{ label: string; value: number; onChange: (v: number) => 
       <span className="text-sky-400 font-mono">{Math.round(value)}%</span>
     </div>
     <input 
+      aria-label={`${label} Percentage Range`}
       type="range" min="0" max="100" value={value} 
       onChange={(e) => onChange(Number(e.target.value))}
       className="w-full h-1 bg-white/10 rounded-sm appearance-none cursor-pointer accent-sky-500"


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to inputs and textareas that lacked explicitly linked `<label>` elements.
🎯 Why: To improve accessibility for screen reader users by providing clear, programmatic descriptions for form controls (e.g., API keys, Character Name, World Seed).
📸 Before/After: Visuals remain unchanged; markup is updated.
♿ Accessibility: Ensures that screen readers can correctly identify the purpose of the modified inputs.

---
*PR created automatically by Jules for task [2744372591765515818](https://jules.google.com/task/2744372591765515818) started by @romeytheAI*