### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix PII leakage in error handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Monetization webhooks (Stripe, GitHub Sponsors) had their payload signature verification logic commented out, exposing endpoints to spoofed payloads that could fraudulently skew revenue metrics. Furthermore, missing encoding caused TypeErrors when `hmac.compare_digest` was run.
 **Learning:** External webhook handling modules need to ensure production secrets are strictly enforced (`os.getenv` without fallback) and that cryptographic digest comparisons properly encode both arguments.
 **Prevention:** Implement automated security scanning to detect commented-out authentication/verification logic and enforce strict typing/byte encoding for Python `hmac` operations.
+
+## 2025-05-24 - Prevent PII Leakage in Error Handlers and Error Boundaries
+**Vulnerability:** Error boundary components and custom Firebase error handlers were leaking sensitive PII (like authentication state, email addresses) by either appending it to console logs (via `errorInfo` or custom payloads) or rendering `error.toString()` directly into the DOM.
+**Learning:** React Error Boundaries receive `errorInfo` which can contain sensitive component stack traces, while custom API wrappers often aggressively bundle auth state to ease debugging, inadvertently creating an exposure vector in production.
+**Prevention:** Sanitize custom error objects so they never serialize PII. Do not render raw error strings to the DOM. When logging to the console, retain observability by logging only safe, structural details of the error without including the raw, nested `errorInfo` or component stack traces unless explicitly sanitized.

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -19,8 +19,8 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Uncaught error:', error, errorInfo);
+  public componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    console.error('Unexpected error:', error);
   }
 
   public render() {
@@ -28,9 +28,6 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div className="p-4 bg-red-900/50 border border-red-500 rounded-lg text-red-200">
           <h2 className="text-xl font-bold mb-2">Something went wrong.</h2>
-          <details className="whitespace-pre-wrap">
-            {this.state.error && this.state.error.toString()}
-          </details>
         </div>
       );
     }

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -20,40 +20,14 @@ export interface FirestoreErrorInfo {
   error: string;
   operationType: OperationType;
   path: string | null;
-  authInfo: {
-    userId: string;
-    email: string;
-    emailVerified: boolean;
-    isAnonymous: boolean;
-    tenantId: string;
-    providerInfo: {
-      providerId: string;
-      displayName: string;
-      email: string;
-      photoUrl: string;
-    }[];
-  }
 }
 
 export function handleFirestoreError(error: unknown, operationType: OperationType, path: string | null) {
   const errInfo: FirestoreErrorInfo = {
     error: error instanceof Error ? error.message : String(error),
-    authInfo: {
-      userId: auth.currentUser?.uid || '',
-      email: auth.currentUser?.email || '',
-      emailVerified: auth.currentUser?.emailVerified || false,
-      isAnonymous: auth.currentUser?.isAnonymous || false,
-      tenantId: auth.currentUser?.tenantId || '',
-      providerInfo: auth.currentUser?.providerData.map(provider => ({
-        providerId: provider.providerId,
-        displayName: provider.displayName || '',
-        email: provider.email || '',
-        photoUrl: provider.photoURL || ''
-      })) || []
-    },
     operationType,
     path
   }
-  console.error('Firestore Error: ', JSON.stringify(errInfo));
+  console.error('Firestore Error:', JSON.stringify(errInfo), error);
   throw new Error(JSON.stringify(errInfo));
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ErrorBoundary` component was directly rendering raw `error.toString()` values to the DOM, which could expose sensitive structural data or backend errors to users. Concurrently, the `FirestoreErrorInfo` interface and `handleFirestoreError` were eagerly bundling the complete authentication state (including emails, user IDs, and provider information) and stringifying it into console logs and nested Error objects, exposing PII in production environments.
🎯 Impact: This exposes user PII to centralized logging platforms, potential browser extensions, or over-the-shoulder viewing in the UI.
🔧 Fix: Removed `authInfo` from `FirestoreErrorInfo` to stop eagerly serializing authentication data into the error boundary. Updated the ErrorBoundary component to remove `error.toString()` from being rendered in the DOM, and removed `errorInfo` (which contains deep React component stacks) from being logged to the console, while still passing the raw error object to preserve essential observability.
✅ Verification: Ran `pnpm lint` and `pnpm test` (all 1034 tests passed) to confirm no types or tests were broken by modifying the `FirestoreErrorInfo` interface.

---
*PR created automatically by Jules for task [7950227235637430940](https://jules.google.com/task/7950227235637430940) started by @romeytheAI*