### PR TITLE
🧹 Implement Quest Objective Parsing for Involved NPCs

### DIFF
--- a/src/data/referenceIndex.test.ts
+++ b/src/data/referenceIndex.test.ts
@@ -374,6 +374,37 @@ describe('Reference Index System', () => {
         expect(metadata?.isLoveInterest).toBe(true);
       }
     });
+
+    it('should identify involved NPCs in quests', () => {
+      // "The Orphan's Cage" mentions "Matron Grelod" in description
+      const questMeta = getQuestMetadata(asQuestId('q_ch1_orphans_cage'));
+      expect(questMeta).not.toBeNull();
+      if (questMeta) {
+        // Grelod's ID is grelod_the_kind
+        expect(questMeta.involvedNpcs).toContain('grelod_the_kind');
+      }
+
+      // "The Thieves Guild" mentions "Brynjolf" in description and objectives
+      const thievesMeta = getQuestMetadata(asQuestId('q_ch4_thieves_guild'));
+      expect(thievesMeta).not.toBeNull();
+      if (thievesMeta) {
+        expect(thievesMeta.involvedNpcs).toContain('brynjolf');
+      }
+    });
+
+    it('should link related quests to NPC metadata', () => {
+      const npcMeta = getNpcMetadata(asNpcId('brynjolf'));
+      expect(npcMeta).not.toBeNull();
+      if (npcMeta) {
+        expect(npcMeta.relatedQuests).toContain('q_ch4_thieves_guild');
+      }
+
+      const grelodMeta = getNpcMetadata(asNpcId('grelod_the_kind'));
+      expect(grelodMeta).not.toBeNull();
+      if (grelodMeta) {
+        expect(grelodMeta.relatedQuests).toContain('q_ch1_orphans_cage');
+      }
+    });
   });
 
   describe('Edge Cases', () => {

--- a/src/data/referenceIndex.ts
+++ b/src/data/referenceIndex.ts
@@ -101,9 +101,13 @@ function buildNpcMetadata(npcId: string, npc: any, index: ReferenceIndex): NpcMe
     }
   }
 
-  // Related quests: not yet supported — quest metadata does not currently track involved NPCs.
-  // TODO: Implement involvedNpcs extraction in buildQuestMetadata (e.g., parse quest objectives).
+  // Related quests
   const relatedQuests: QuestId[] = [];
+  for (const questMetadata of index.questMetadata.values()) {
+    if (questMetadata.involvedNpcs.includes(npcId as NpcId)) {
+      relatedQuests.push(questMetadata.id);
+    }
+  }
 
   return {
     id: npcId as NpcId,
@@ -147,7 +151,28 @@ function buildQuestMetadata(questId: string, quest: any, index: ReferenceIndex):
 
   // Find involved NPCs by scanning quest objectives and descriptions
   const involvedNpcs: NpcId[] = [];
-  // This could be expanded to parse quest text for NPC references
+
+  // Create a blob of text to search for NPC references
+  const searchableText = [
+    quest.title,
+    quest.description,
+    ...(quest.objectives || []).map((obj: any) => obj.description),
+  ].join(' ');
+
+  // Scan for NPC IDs and names
+  for (const [npcId, npc] of Object.entries(NPCS)) {
+    const npcName = npc.name || npcId;
+    // Pattern to match full word only, case-insensitive
+    // We escape special characters in the name/id and use word boundaries
+    const escapedName = npcName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedId = npcId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    const pattern = new RegExp(`\\b(${escapedName}|${escapedId})\\b`, 'i');
+
+    if (pattern.test(searchableText)) {
+      involvedNpcs.push(npcId as NpcId);
+    }
+  }
 
   return {
     id: questId as QuestId,


### PR DESCRIPTION
🎯 **What:** Implemented logic to parse quest titles, descriptions, and objectives for mentions of NPC names or IDs. This data is then used to populate `involvedNpcs` in `QuestMetadata` and `relatedQuests` in `NpcMetadata`.
💡 **Why:** This improves the rich metadata available in the `ReferenceIndex`, allowing for bidirectional lookups between NPCs and the quests they are involved in, fulfilling a TODO item in the codebase.
✅ **Verification:** Added new unit tests in `src/data/referenceIndex.test.ts` verifying that NPCs are correctly identified in quests (e.g., Grelod in "The Orphan's Cage") and that NPCs correctly link to those quests. Verified implementation via code review and static analysis.
✨ **Result:** Enhanced `ReferenceIndex` metadata with automatic NPC-Quest linking.

---
*PR created automatically by Jules for task [8727728884675882816](https://jules.google.com/task/8727728884675882816) started by @romeytheAI*